### PR TITLE
Introduce PAX header support

### DIFF
--- a/src/Parser/Header.php
+++ b/src/Parser/Header.php
@@ -36,6 +36,7 @@ use JakubBoucek\Tar\Exception\InvalidArgumentException;
 class Header
 {
     private string $content;
+    /** @var array<string, string|int> */
     private array $pax = [];
 
     public function __construct(string $content)

--- a/src/Parser/Header.php
+++ b/src/Parser/Header.php
@@ -50,7 +50,7 @@ class Header
 
     public function harvestPaxData(string $paxData): void
     {
-        foreach (explode(PHP_EOL, $paxData) as $record) {
+        foreach (explode("\n", $paxData) as $record) {
             if ($record === '') {
                 continue;
             }

--- a/src/Parser/Header.php
+++ b/src/Parser/Header.php
@@ -55,8 +55,8 @@ class Header
             if ($record === '') {
                 continue;
             }
-            preg_match_all('/^(\d+) ([^=]+)=(.*)$/', $record, $matches);
-            if (count($matches) !== 4) {
+            $matchesFound = preg_match_all('/^(\d+) ([^=]+)=(.*)$/', $record, $matches);
+            if (!$matchesFound) {
                 throw new InvalidArchiveFormatException(
                     sprintf('Invalid Pax header record format: %s', $record)
                 );

--- a/src/StreamReader.php
+++ b/src/StreamReader.php
@@ -173,6 +173,7 @@ class StreamReader implements IteratorAggregate
             case 'x':
                 $paxHeader = $header;
                 $paxData = fread($this->stream, $paxHeader->getSize()); // @phpstan-ignore argument.type
+                fseek($this->stream, 512 - ($paxHeader->getSize() % 512), SEEK_CUR); // Skip null byte padding
                 if ($paxData === false) {
                     throw new InvalidArchiveFormatException(
                         'Invalid TAR archive format: Unexpected end of file, expected PAX header data'

--- a/src/StreamReader.php
+++ b/src/StreamReader.php
@@ -172,7 +172,7 @@ class StreamReader implements IteratorAggregate
         switch($header->getType()) {
             case 'x':
                 $paxHeader = $header;
-                $paxData = fread($this->stream, $paxHeader->getSize());
+                $paxData = fread($this->stream, $paxHeader->getSize()); // @phpstan-ignore argument.type
                 if ($paxData === false) {
                     throw new InvalidArchiveFormatException(
                         'Invalid TAR archive format: Unexpected end of file, expected PAX header data'

--- a/src/StreamReader.php
+++ b/src/StreamReader.php
@@ -22,8 +22,6 @@ class StreamReader implements IteratorAggregate
     /** @var resource */
     private $stream;
 
-    private ?Header $globalPaxHeader = null;
-
     /**
      * @param resource $stream Stream resource of TAR file
      */
@@ -180,9 +178,6 @@ class StreamReader implements IteratorAggregate
                 break;
         }
 
-        if ($this->globalPaxHeader) {
-            $header->mergePaxHeader($this->globalPaxHeader);
-        }
         if ($paxHeader) {
             $header->mergePaxHeader($paxHeader);
         }

--- a/src/StreamReader.php
+++ b/src/StreamReader.php
@@ -173,6 +173,11 @@ class StreamReader implements IteratorAggregate
             case 'x':
                 $paxHeader = $header;
                 $paxData = fread($this->stream, $paxHeader->getSize());
+                if ($paxData === false) {
+                    throw new InvalidArchiveFormatException(
+                        'Invalid TAR archive format: Unexpected end of file, expected PAX header data'
+                    );
+                }
                 $paxHeader->harvestPaxData($paxData);
                 $header = $this->readHeader();
                 break;

--- a/tests/Parser/PaxHeaderTest.php
+++ b/tests/Parser/PaxHeaderTest.php
@@ -30,9 +30,9 @@ class PaxHeaderTest extends TestCase
 
         if ($totalSize > self::MAX_USTAR_SIZE) {
             // Generate a pax header and data record for a file larger than 8GB
-            $data = implode(PHP_EOL, [
+            $data = implode("\n", [
                     implode(' ', array_reverse([$data = 'size=' . $totalSize, strlen($data)])),
-                ]) . PHP_EOL;
+                ]) . "\n";
 
             yield str_pad(implode('', [
                 /* 0 */ 'name' => str_pad('massive_file.txt', 100, "\0"),

--- a/tests/Parser/PaxHeaderTest.php
+++ b/tests/Parser/PaxHeaderTest.php
@@ -33,13 +33,15 @@ class PaxHeaderTest extends TestCase
             $data = implode("\n", [
                     implode(' ', array_reverse([$data = 'size=' . $totalSize, strlen($data)])),
                 ]) . "\n";
+            $dataLength = strlen($data);
+            $data = str_pad($data, 512 * ceil($dataLength / 512), "\0");
 
             yield str_pad(implode('', [
                 /* 0 */ 'name' => str_pad('massive_file.txt', 100, "\0"),
                 /*100*/ 'mode' => str_pad('', 8, "\0"),
                 /*108*/ 'uid' => str_pad('', 8, "\0"),
                 /*116*/ 'gid' => str_pad('', 8, "\0"),
-                /*100*/ 'size' => str_pad(decoct(strlen($data)), 12, "\0"),
+                /*100*/ 'size' => str_pad(decoct($dataLength), 12, "\0"),
                 /*136*/ 'mtime' => str_pad('', 12, "\0"),
                 /*148*/ 'chksum' => str_pad('', 8, "\0"),
                 /*156*/ 'typeflag' => 'x',

--- a/tests/Parser/PaxHeaderTest.php
+++ b/tests/Parser/PaxHeaderTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace JakubBoucek\Tar\Tests\Parser;
+
+use Generator;
+use JakubBoucek\Tar\StreamReader;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../ResourceGenerators/MassiveFileStreamWrapper.php';
+
+class PaxHeaderTest extends TestCase
+{
+    const MAX_USTAR_SIZE = 8589934591; // 8GB - 1
+
+    protected function setUp(): void
+    {
+        if (getenv('CI') != 'true' && getenv('TEST_MASSIVE_FILE') != 'true') {
+            $this->markTestSkipped('Massive file test is skipped. Set TEST_MASSIVE_FILE=true to run it.');
+        }
+        parent::setUp();
+    }
+
+    protected function generateSingleFile(?int $chunkSize = null, ?int $totalSize = null): Generator
+    {
+        $chunkSize ??= 1024 * 1024; // 1MB chunks
+        $totalSize ??= 10 * 1024 * $chunkSize; // 10GB
+        assert($totalSize > $chunkSize);
+        $chunks = floor($totalSize / $chunkSize);
+        $extra = $totalSize % $chunkSize;
+
+        if ($totalSize > self::MAX_USTAR_SIZE) {
+            // Generate a pax header and data record for a file larger than 8GB
+            $data = implode(PHP_EOL, [
+                    implode(' ', array_reverse([$data = 'size=' . $totalSize, strlen($data)])),
+                ]) . PHP_EOL;
+
+            yield str_pad(implode('', [
+                /* 0 */ 'name' => str_pad('massive_file.txt', 100, "\0"),
+                /*100*/ 'mode' => str_pad('', 8, "\0"),
+                /*108*/ 'uid' => str_pad('', 8, "\0"),
+                /*116*/ 'gid' => str_pad('', 8, "\0"),
+                /*100*/ 'size' => str_pad(decoct(strlen($data)), 12, "\0"),
+                /*136*/ 'mtime' => str_pad('', 12, "\0"),
+                /*148*/ 'chksum' => str_pad('', 8, "\0"),
+                /*156*/ 'typeflag' => 'x',
+                /*157*/ 'linkname' => str_pad('', 100, "\0"),
+                /*257*/ 'magic' => "ustar\0",
+                /*263*/ 'version' => str_pad('', 2, "\0"),
+                /*265*/ 'uname' => str_pad('', 32, "\0"),
+                /*297*/ 'gname' => str_pad('', 32, "\0"),
+                /*329*/ 'devmajor' => str_pad('', 8, "\0"),
+                /*337*/ 'devminor' => str_pad('', 8, "\0"),
+                /*345*/ 'prefix' => str_pad('PaxHeaders.0', 155, "\0"),
+            ]), 512, "\0");
+            yield $data;
+        }
+
+        yield str_pad(implode('', [
+            /* 0 */ 'name' => str_pad('massive_file.txt', 100, "\0"),
+            /*100*/ 'mode' => str_pad('', 8, "\0"),
+            /*108*/ 'uid' => str_pad('', 8, "\0"),
+            /*116*/ 'gid' => str_pad('', 8, "\0"),
+            /*100*/ 'size' => str_pad(decoct(min(octdec('77777777777'), $totalSize)), 12, "\0"),
+            /*136*/ 'mtime' => str_pad('', 12, "\0"),
+            /*148*/ 'chksum' => str_pad('', 8, "\0"),
+            /*156*/ 'typeflag' => '0',
+            /*157*/ 'linkname' => str_pad('', 100, "\0"),
+            /*257*/ 'magic' => "ustar\0",
+            /*263*/ 'version' => str_pad('', 2, "\0"),
+            /*265*/ 'uname' => str_pad('', 32, "\0"),
+            /*297*/ 'gname' => str_pad('', 32, "\0"),
+            /*329*/ 'devmajor' => str_pad('', 8, "\0"),
+            /*337*/ 'devminor' => str_pad('', 8, "\0"),
+            /*345*/ 'prefix' => str_pad('', 155, "\0"),
+        ]), 512, "\0");
+
+        $alphabet = range('A', 'Z');
+        for ($i = 0; $i < $chunks; $i++) {
+            yield str_repeat($alphabet[$i % 26], $chunkSize);
+        }
+
+        if ($extra > 0) {
+            yield str_repeat('#', $extra);
+        }
+    }
+
+    public function fileCountProvider()
+    {
+        return [
+            'one' => [1],
+            'two' => [2],
+            'three' => [3],
+        ];
+    }
+
+    /**
+     * @dataProvider fileCountProvider
+     */
+    public function testPaxHeader(int $fileCount): void
+    {
+        $fileGenerator = (function () use ($fileCount) {
+            for ($i = 0; $i < $fileCount; $i++) {
+                yield from $this->generateSingleFile();
+            }
+        })();
+        $resource = fopen('massive-file://', 'r', context: stream_context_create([
+            'massive-file' => ['generator' => $fileGenerator],
+        ]));
+        $this->assertIsResource($resource);
+
+        try {
+            $streamReader = new StreamReader($resource);
+
+            $iterator = $streamReader->getIterator();
+            $count = 0;
+            foreach ($iterator as $file) {
+                $count++;
+                $fileResource = $file->getContent()->detach();
+                $bytesRead = 0;
+                while (!feof($fileResource)) {
+                    $bytesRead += strlen(fread($fileResource, 1024 ** 2));
+                }
+                $this->assertSame($file->getSize(), $bytesRead);
+            }
+            $this->assertSame($fileCount, $count);
+        } finally {
+            fclose($resource);
+        }
+    }
+}

--- a/tests/ResourceGenerators/MassiveFileStreamWrapper.php
+++ b/tests/ResourceGenerators/MassiveFileStreamWrapper.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace JakubBoucek\Tar\Tests\ResourceGenerators;
+
+use Generator;
+use JakubBoucek\Tar\Exception\RuntimeException;
+
+class MassiveFileStreamWrapper
+{
+    public $context;
+    protected Generator $generator;
+    protected string $buffer = '';
+    protected int $position = 0;
+
+    public function stream_open(string $path, string $mode, int $options, ?string &$opened_path): bool
+    {
+        $options = stream_context_get_options($this->context);
+        if (!array_key_exists('massive-file', $options)) {
+            return false;
+        }
+        $options = $options['massive-file'];
+
+        if (!array_key_exists('generator', $options)) {
+            return false;
+        }
+        $this->generator = $options['generator'];
+
+        return true;
+    }
+
+    public function stream_eof(): bool
+    {
+        return !$this->generator->valid() && strlen($this->buffer) === 0;
+    }
+
+    public function stream_read(int $count): string
+    {
+        while ($this->generator->valid() && strlen($this->buffer) < $count) {
+            $this->buffer .= $this->generator->current();
+            $this->generator->next();
+        }
+        $data = substr($this->buffer, 0, $count);
+        $this->buffer = substr($this->buffer, $count);
+        $this->position += strlen($data);
+        return $data;
+    }
+
+    public function stream_tell(): int
+    {
+        return $this->position;
+    }
+
+    public function stream_seek(int $offset, int $whence): bool
+    {
+        if ($whence === SEEK_END) {
+            throw new RuntimeException('Seeking from the end is not supported');
+        }
+
+        if (
+            ($whence === SEEK_CUR && $offset < 0)
+            || ($whence === SEEK_SET && $offset < $this->position)
+        ) {
+            throw new RuntimeException('Seeking backwards is not supported');
+        }
+
+        $newPosition = $whence === SEEK_CUR ? $this->position + $offset : $offset;
+        while ($this->position < $newPosition) {
+            // Limit read to 1 MiB, to reduce memory usage
+            $this->stream_read(min($newPosition - $this->position, 1204 ** 2));
+        }
+        return true;
+    }
+
+    public function stream_stat(): array
+    {
+        return [];
+    }
+}
+
+stream_wrapper_register('massive-file', MassiveFileStreamWrapper::class)
+|| throw new \RuntimeException('Failed to register stream wrapper ' . MassiveFileStreamWrapper::class);


### PR DESCRIPTION
In my use case, I'm pulling very large files from a docker volume, using the [Docker HTTP API endpoint](https://docs.docker.com/reference/api/engine/version/v1.47/#tag/Container/operation/ContainerArchive). Because the files I'm pulling are larger than 8 GiB, the Docker engine prefixes the data stream with a PAX header [docs](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/pax.html#tag_20_92_13). They do this to indicate the size of the file is larger than 8 GiB (`tar` format has a limitation the makes it so it can only record the size of the file as 8 GiB).

This PR should introduce support for the `size` parameter in a PAX header. There are other headers that can be implemented, but I wanted to get this feature in, because it's the core of how the header can be processed. As other use cases come up, they can be added.

The test added takes quite a long time to run. It tests a tar archive that contains 1 x 10 GiB file, 2 x 10 GiB files, and 3 x 10 GiB files, to ensure it would work on a directory of very large files. Currently the test is configured to run if the `CI` env var is set, which GitHub Actions has set on their workflows ([docs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables)). For local development, they will be marked as skipped, but a local env var of `TEST_MASSIVE_FILE=true` would allow it to run as well. This way we know the tests pass before merging a PR, but development of features unrelated to these large files is faster to iterate on. If this should be changed so that CI runs are faster, I am happy to do so.